### PR TITLE
Action return value

### DIFF
--- a/AssetController.php
+++ b/AssetController.php
@@ -32,7 +32,7 @@ class AssetController extends \yii\console\controllers\AssetController
      */
     public $verbose = false;
     /**
-       @var boolean quiet;  do  not  write  anything to standard output.
+     * @var boolean quiet;  do  not  write  anything to standard output.
      */
     public $quiet = false;
     /**

--- a/AssetController.php
+++ b/AssetController.php
@@ -74,7 +74,7 @@ class AssetController extends \yii\console\controllers\AssetController
     public function actionClean()
     {
         $this->cleanAssetsDir();
-        return true;
+        return self::EXIT_CODE_NORMAL;
     }
 
     public function cleanAssetsDir()


### PR DESCRIPTION
I tried to use your console controller to clear assets during deploy. I use Mage deploy. It requires a valid return value (which is zero) to proceed with all the tasks.
I have changed return value to the correct one. 
You can check default yii2 migrate console controller for the same solution.
